### PR TITLE
setup_cmake for my laptop; MAKEGRID dep in VMEC?

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,11 +9,11 @@ find_package (Git)
 
 option (USE_SSH "Use ssh to access git repos" OFF)
 
-if ($USE_SSH)
+if (${USE_SSH})
     set (URL_PROTOCOL "git@")
-else
+else ()
     set (URL_PROTOCOL "https://")
-endif
+endif ()
 
 #  Define a macro to register new projects.
 macro (register_project name dir url default_tag)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ register_project(parvmec
                  PARVMEC
                  git@github.com:ORNL-Fusion/PARVMEC.git
                  experimental_vmec10
-                 MAKEGRID
+#                 MAKEGRID
                  LIBSTELL)
 
 # Register MAKEGRID

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,8 +70,8 @@ endmacro ()
 register_project(parvmec
                  PARVMEC
                  ${URL_PROTOCOL}github.com:ORNL-Fusion/PARVMEC.git
-                 experimental_vmec10
-#                 MAKEGRID
+                 master_dev
+                 MAKEGRID
                  LIBSTELL)
 
 # Register MAKEGRID
@@ -85,6 +85,6 @@ register_project(makegrid
 register_project(libstell
                  LIBSTELL
                  ${URL_PROTOCOL}github.com:ORNL-Fusion/LIBSTELL.git
-                 experimental_vmec10
+                 master_dev
                  )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ endmacro ()
 # Register PARVMEC
 register_project(parvmec
                  PARVMEC
-                 https://github.com/ORNL-Fusion/PARVMEC.git
+                 git@github.com:ORNL-Fusion/PARVMEC.git
                  master
                  MAKEGRID
                  LIBSTELL)
@@ -70,12 +70,12 @@ register_project(parvmec
 # Register MAKEGRID
 register_project(makegrid
                  MAKEGRID
-                 https://github.com/ORNL-Fusion/MAKEGRID.git
+                 git@github.com/ORNL-Fusion/MAKEGRID.git
                  master
                  LIBSTELL)
 
 # Register LIBSTELL
 register_project(libstell
                  LIBSTELL
-                 https://github.com/ORNL-Fusion/LIBSTELL.git
+                 git@github.com/ORNL-Fusion/LIBSTELL.git
                  master)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,14 @@ enable_testing ()
 include (FetchContent)
 find_package (Git)
 
+option (USE_SSH "Use ssh to access git repos" OFF)
+
+if ($USE_SSH)
+    set (URL_PROTOCOL "git@")
+else
+    set (URL_PROTOCOL "https://")
+endif
+
 #  Define a macro to register new projects.
 macro (register_project name dir url default_tag)
     option (BUILD_${dir} "Build ${name} subproject." OFF)
@@ -62,7 +70,7 @@ endmacro ()
 # Register PARVMEC
 register_project(parvmec
                  PARVMEC
-                 git@github.com:ORNL-Fusion/PARVMEC.git
+                 ${URL_PROTOCOL}github.com:ORNL-Fusion/PARVMEC.git
                  experimental_vmec10
 #                 MAKEGRID
                  LIBSTELL)
@@ -70,12 +78,13 @@ register_project(parvmec
 # Register MAKEGRID
 register_project(makegrid
                  MAKEGRID
-                 git@github.com:ORNL-Fusion/MAKEGRID.git
+                 ${URL_PROTOCOL}github.com:ORNL-Fusion/MAKEGRID.git
                  master_dev
                  LIBSTELL)
 
 # Register LIBSTELL
 register_project(libstell
                  LIBSTELL
-                 git@github.com:ORNL-Fusion/LIBSTELL.git
-                 experimental_vmec10)
+                 ${URL_PROTOCOL}github.com:ORNL-Fusion/LIBSTELL.git
+                 experimental_vmec10
+                 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,12 +70,12 @@ register_project(parvmec
 # Register MAKEGRID
 register_project(makegrid
                  MAKEGRID
-                 git@github.com/ORNL-Fusion/MAKEGRID.git
+                 git@github.com:ORNL-Fusion/MAKEGRID.git
                  master_dev
                  LIBSTELL)
 
 # Register LIBSTELL
 register_project(libstell
                  LIBSTELL
-                 git@github.com/ORNL-Fusion/LIBSTELL.git
+                 git@github.com:ORNL-Fusion/LIBSTELL.git
                  experimental_vmec10)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,6 @@ register_project(parvmec
                  PARVMEC
                  https://github.com/ORNL-Fusion/PARVMEC.git
                  master
-                 MAKEGRID
                  LIBSTELL)
 
 # Register MAKEGRID

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ endmacro ()
 register_project(parvmec
                  PARVMEC
                  git@github.com:ORNL-Fusion/PARVMEC.git
-                 master
+                 experimental_vmec10
                  MAKEGRID
                  LIBSTELL)
 
@@ -71,11 +71,11 @@ register_project(parvmec
 register_project(makegrid
                  MAKEGRID
                  git@github.com/ORNL-Fusion/MAKEGRID.git
-                 master
+                 master_dev
                  LIBSTELL)
 
 # Register LIBSTELL
 register_project(libstell
                  LIBSTELL
                  git@github.com/ORNL-Fusion/LIBSTELL.git
-                 master)
+                 experimental_vmec10)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,6 @@ include (FetchContent)
 find_package (Git)
 
 option (USE_SSH "Use ssh to access git repos" OFF)
-
 if (${USE_SSH})
     set (URL_PROTOCOL "git@")
 else ()
@@ -40,7 +39,7 @@ macro (register_project name dir url default_tag)
             )
 
 #  Add a taraget to pull the latest version before building. Note dependency is
-#  registered in the sub project CMakeList.txt. Not sue how this should handel
+#  registered in the sub project CMakeList.txt. Not sure how this should handle
 #  multiple targets in a project yet. Name must match the subproject pull_
 #  dependency.
             add_custom_target(
@@ -51,7 +50,7 @@ macro (register_project name dir url default_tag)
             )
         endif ()
 
-# Any thing after the the tag is assumed to be a project dependency.
+# Anything after the the tag is assumed to be a project dependency.
         set (depends "${ARGN}")
         foreach (project IN LISTS depends)
             set (BUILD_${project} ON)
@@ -60,7 +59,7 @@ macro (register_project name dir url default_tag)
 endmacro ()
 
 #  Registers the projects. By specifying a name, directory, git url, tag and
-#  option dependencies.
+#  optional dependencies.
 #register_project(example_project
 #                 PROJECT_DIR
 #                 https://url.to.project
@@ -88,3 +87,4 @@ register_project(libstell
                  ${URL_PROTOCOL}github.com:ORNL-Fusion/LIBSTELL.git
                  experimental_vmec10
                  )
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ endmacro ()
 register_project(parvmec
                  PARVMEC
                  ${URL_PROTOCOL}github.com:ORNL-Fusion/PARVMEC.git
-                 master_dev
+                 master
                  MAKEGRID
                  LIBSTELL)
 
@@ -78,13 +78,13 @@ register_project(parvmec
 register_project(makegrid
                  MAKEGRID
                  ${URL_PROTOCOL}github.com:ORNL-Fusion/MAKEGRID.git
-                 master_dev
+                 master
                  LIBSTELL)
 
 # Register LIBSTELL
 register_project(libstell
                  LIBSTELL
                  ${URL_PROTOCOL}github.com:ORNL-Fusion/LIBSTELL.git
-                 master_dev
+                 master
                  )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ register_project(parvmec
                  PARVMEC
                  https://github.com/ORNL-Fusion/PARVMEC.git
                  master
+                 MAKEGRID
                  LIBSTELL)
 
 # Register MAKEGRID

--- a/setup_cmake
+++ b/setup_cmake
@@ -8,7 +8,7 @@ BUILD_TYPE=Release
 
 MACHINE_ID=`uname -n`
 
-echo Building v3fit suite for machine $MACHINE_ID
+echo Building stellarator tools for machine $MACHINE_ID
 echo
 
 if [ $# -eq 1 ]
@@ -37,6 +37,19 @@ then
     # Config for Mark Cianciosa's ORNL machine.
     cmake -DCMAKE_BUILD_TYPE:String=$BUILD_TYPE \
           -DBUILD_MAKEGRID=ON                   \
+          ../
+
+elif [ $MACHINE_ID == "Nebuchadnezaar" ]
+then
+    # Config for Jonathan Schilling's laptop running Arch Linux.
+    # -fallow-argument-mismatch is needed for GCC-10.
+    cmake -DCMAKE_BUILD_TYPE:String=$BUILD_TYPE           \
+          -DBUILD_PARVMEC=ON                              \
+          -DBUILD_MAKEGRID=ON                             \
+          -DBUILD_TAG_LIBSTELL=experimental_vmec10        \
+          -DBUILD_TAG_MAKEGRID=master_dev                 \
+          -DBUILD_TAG_PARVMEC=experimental_vmec10         \
+          -DCMAKE_Fortran_FLAGS=-fallow-argument-mismatch \
           ../
 
 else

--- a/setup_cmake
+++ b/setup_cmake
@@ -46,10 +46,6 @@ then
     # -fallow-argument-mismatch is needed for GCC-10.
     cmake -DCMAKE_BUILD_TYPE:String=$BUILD_TYPE           \
           -DBUILD_PARVMEC=ON                              \
-          -DBUILD_MAKEGRID=ON                             \
-          -DBUILD_TAG_LIBSTELL=experimental_vmec10        \
-          -DBUILD_TAG_MAKEGRID=master_dev                 \
-          -DBUILD_TAG_PARVMEC=experimental_vmec10         \
           -DCMAKE_Fortran_FLAGS=-fallow-argument-mismatch \
           ../
 

--- a/setup_cmake
+++ b/setup_cmake
@@ -39,9 +39,10 @@ then
           -DBUILD_MAKEGRID=ON                   \
           ../
 
-elif [ $MACHINE_ID == "Nebuchadnezaar" ]
+elif [ $MACHINE_ID == "Nebuchadnezaar" ] || \
+     [ $MACHINE_ID == "Z820" ]
 then
-    # Config for Jonathan Schilling's laptop running Arch Linux.
+    # Config for Jonathan Schilling's Arch Linux machines.
     # -fallow-argument-mismatch is needed for GCC-10.
     cmake -DCMAKE_BUILD_TYPE:String=$BUILD_TYPE           \
           -DBUILD_PARVMEC=ON                              \

--- a/setup_cmake
+++ b/setup_cmake
@@ -45,6 +45,7 @@ then
     # Config for Jonathan Schilling's Arch Linux machines.
     # -fallow-argument-mismatch is needed for GCC-10.
     cmake -DCMAKE_BUILD_TYPE:String=$BUILD_TYPE           \
+          -DUSE_SSH=ON                                    \
           -DBUILD_PARVMEC=ON                              \
           -DCMAKE_Fortran_FLAGS=-fallow-argument-mismatch \
           ../


### PR DESCRIPTION
I added an entry to `setup_cmake` for my laptop running Arch Linux. All required libraries were found and the tests executed fine.
I needed to specify `-fallow-argument-mismatch` to be able to build `LIBSTELL`; `ezcdf*` is one part of the code where this requirement appears.

The `CMakeLists.txt` in the root folder lists `MAKEGRID` as a dependency for `VMEC`.
Is this indented to have `MAKEGRID` be re-built every time someone changes something in `LIBSTELL` which might also affect `MAKEGRID` or could this dependency be removed (or is there some other reason I missed out completely)?

Please don't delete this branch when merging so that I can keep adding things to it.