### PR TITLE
add link to VMEC-internal documentation repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ subprojects are.
 * [MAKEGRID](https://github.com/ORNL-Fusion/MAKEGRID) Generate vacuum fields from coil models. 
 * [VMEC](https://github.com/ORNL-Fusion/PARVMEC) 3D Equilibrium solver with nested flux surfaces.
 * [DESCUR](https://github.com/ORNL-Fusion/DESCUR)
+* [VMEC-internals](https://github.com/jonathanschilling/vmec-internals) Some VMEC-internal documentation


### PR DESCRIPTION
I added a link to a repository containing some VMEC-internal documentation.