### PR TITLE
Fix siesta mpi test errors

### DIFF
--- a/.github/workflows/ci_test.yaml
+++ b/.github/workflows/ci_test.yaml
@@ -22,7 +22,9 @@ jobs:
             - name: Clone Repo
               shell: bash
               working-directory: ${{runner.workspace}}
-              run: git clone https://github.com/ORNL-Fusion/Stellarator-Tools.git ${{runner.workspace}}/Stellarator-Tools
+              run: |
+                git clone https://github.com/ORNL-Fusion/Stellarator-Tools.git ${{runner.workspace}}/Stellarator-Tools
+                git checkout ${{github.ref_name}}
             - name: Create build directory.
               working-directory: ${{runner.workspace}}/Stellarator-Tools
               run: cmake -E make_directory build

--- a/.github/workflows/ci_test.yaml
+++ b/.github/workflows/ci_test.yaml
@@ -24,6 +24,7 @@ jobs:
               working-directory: ${{runner.workspace}}
               run: |
                 git clone https://github.com/ORNL-Fusion/Stellarator-Tools.git ${{runner.workspace}}/Stellarator-Tools
+                cd ${{runner.workspace}}/Stellarator-Tools
                 git checkout ${{github.ref_name}}
             - name: Create build directory.
               working-directory: ${{runner.workspace}}/Stellarator-Tools

--- a/.github/workflows/ci_test_master.yaml
+++ b/.github/workflows/ci_test_master.yaml
@@ -22,7 +22,9 @@ jobs:
             - name: Clone Repo
               shell: bash
               working-directory: ${{runner.workspace}}
-              run: git clone https://github.com/ORNL-Fusion/Stellarator-Tools.git ${{runner.workspace}}/Stellarator-Tools
+              run: |
+                git clone https://github.com/ORNL-Fusion/Stellarator-Tools.git ${{runner.workspace}}/Stellarator-Tools
+                git checkout ${{github.ref_name}}
             - name: Create build directory.
               working-directory: ${{runner.workspace}}/Stellarator-Tools
               run: cmake -E make_directory build

--- a/.github/workflows/ci_test_master.yaml
+++ b/.github/workflows/ci_test_master.yaml
@@ -24,6 +24,7 @@ jobs:
               working-directory: ${{runner.workspace}}
               run: |
                 git clone https://github.com/ORNL-Fusion/Stellarator-Tools.git ${{runner.workspace}}/Stellarator-Tools
+                cd ${{runner.workspace}}/Stellarator-Tools
                 git checkout ${{github.ref_name}}
             - name: Create build directory.
               working-directory: ${{runner.workspace}}/Stellarator-Tools

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,35 +120,17 @@ endmacro ()
 #                   SUB) #Optional Sub project directories.
 #-------------------------------------------------------------------------------
 
+# Register LIBSTELL
+register_project(libstell
+                 LIBSTELL
+                 ${URL_PROTO}github.com${URL_SEP}ORNL-Fusion/LIBSTELL.git
+                 master)
+
 register_project(booz_xform
                  BOOZ_XFORM
                  ${URL_PROTO}github.com${URL_SEP}ORNL-Fusion/BOOZ_XFORM.git
                  master
                  LIBSTELL)
-
-# Register V3FIT
-register_project(v3fit
-                 V3FIT
-                 ${URL_PROTO}github.com${URL_SEP}cianciosa/V3FIT.git
-                 master
-                 SIESTA
-                 V3RFUN
-                 LGRID)
-
-# Register V3RFUN
-register_project(v3rfun
-                 V3RFUN
-                 ${URL_PROTO}github.com${URL_SEP}ORNL-Fusion/V3RFUN.git
-                 master
-                 LIBSTELL)
-
-# Register SIESTA
-register_project(siesta
-                 SIESTA
-                 ${URL_PROTO}github.com${URL_SEP}ORNL-Fusion/SIESTA.git
-                 master
-                 PARVMEC
-                 BMW)
 
 # Register LGRID
 register_project(lgrid
@@ -157,12 +139,12 @@ register_project(lgrid
                  master
                  LIBSTELL)
 
-# Register SURFACE
-register_project(surface
-                 SURFACE
-                 ${URL_PROTO}github.com${URL_SEP}ORNL-Fusion/SURFACE.git
+# Register V3RFUN
+register_project(v3rfun
+                 V3RFUN
+                 ${URL_PROTO}github.com${URL_SEP}ORNL-Fusion/V3RFUN.git
                  master
-                 BMW)
+                 LIBSTELL)
 
 # Register BMW
 register_project(bmw
@@ -178,6 +160,13 @@ register_project(descur
                  master
                  LIBSTELL)
 
+# Register MAKEGRID
+register_project(makegrid
+                 MAKEGRID
+                 ${URL_PROTO}github.com${URL_SEP}ORNL-Fusion/MAKEGRID.git
+                 master
+                 LIBSTELL)
+
 # Register PARVMEC
 register_project(parvmec
                  PARVMEC
@@ -186,15 +175,26 @@ register_project(parvmec
                  MAKEGRID
                  LIBSTELL)
 
-# Register MAKEGRID
-register_project(makegrid
-                 MAKEGRID
-                 ${URL_PROTO}github.com${URL_SEP}ORNL-Fusion/MAKEGRID.git
+# Register SIESTA
+register_project(siesta
+                 SIESTA
+                 ${URL_PROTO}github.com${URL_SEP}ORNL-Fusion/SIESTA.git
                  master
-                 LIBSTELL)
+                 PARVMEC
+                 BMW)
 
-# Register LIBSTELL
-register_project(libstell
-                 LIBSTELL
-                 ${URL_PROTO}github.com${URL_SEP}ORNL-Fusion/LIBSTELL.git
-                 master)
+# Register V3FIT
+register_project(v3fit
+                 V3FIT
+                 ${URL_PROTO}github.com${URL_SEP}cianciosa/V3FIT.git
+                 master
+                 SIESTA
+                 V3RFUN
+                 LGRID)
+
+# Register SURFACE
+register_project(surface
+                 SURFACE
+                 ${URL_PROTO}github.com${URL_SEP}ORNL-Fusion/SURFACE.git
+                 master
+                 BMW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,10 @@ endif ()
 #-------------------------------------------------------------------------------
 #  Define a macro to register new projects.
 #-------------------------------------------------------------------------------
-macro (register_project name dir url default_tag)
+macro (register_project name url default_tag)
+    string (TOUPPER ${name} dir)
+    set (depends "${ARGN}")
+
     option (BUILD_${dir} "Build ${name} subproject." OFF)
     set (BUILD_TAG_${dir} ${default_tag} CACHE STRING "Name of the tag to checkout.")
 
@@ -79,7 +82,7 @@ macro (register_project name dir url default_tag)
             SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${dir}
         )
 
-        FetchContent_MakeAvailable(${name})
+        FetchContent_MakeAvailable(${name} ${depends})
 
         if (GIT_FOUND)
 #  By default cmake clones projects in a headless state. After the repo is
@@ -104,7 +107,8 @@ macro (register_project name dir url default_tag)
 # Anything after the the tag is assumed to be a project dependency.
         set (depends "${ARGN}")
         foreach (project IN LISTS depends)
-            set (BUILD_${project} ON CACHE BOOL "Build ${project}" FORCE)
+            string (TOUPPER ${project} dep)
+            set (BUILD_${dep} ON CACHE BOOL "Build ${dep}" FORCE)
         endforeach ()
     endif ()
 endmacro ()
@@ -122,79 +126,68 @@ endmacro ()
 
 # Register LIBSTELL
 register_project(libstell
-                 LIBSTELL
                  ${URL_PROTO}github.com${URL_SEP}ORNL-Fusion/LIBSTELL.git
                  master)
 
 register_project(booz_xform
-                 BOOZ_XFORM
                  ${URL_PROTO}github.com${URL_SEP}ORNL-Fusion/BOOZ_XFORM.git
                  master
-                 LIBSTELL)
+                 libstell)
 
 # Register LGRID
 register_project(lgrid
-                 LGRID
                  ${URL_PROTO}github.com${URL_SEP}ORNL-Fusion/LGRID.git
                  master
-                 LIBSTELL)
+                 libstell)
 
 # Register V3RFUN
 register_project(v3rfun
-                 V3RFUN
                  ${URL_PROTO}github.com${URL_SEP}ORNL-Fusion/V3RFUN.git
                  master
-                 LIBSTELL)
+                 libstell)
 
 # Register BMW
 register_project(bmw
-                 BMW
                  ${URL_PROTO}github.com${URL_SEP}ORNL-Fusion/BMW.git
                  master
-                 LIBSTELL)
+                 libstell)
 
 # Register DESCUR
 register_project(descur
-                 DESCUR
                  ${URL_PROTO}github.com${URL_SEP}ORNL-Fusion/DESCUR.git
                  master
-                 LIBSTELL)
+                 libstell)
 
 # Register MAKEGRID
 register_project(makegrid
-                 MAKEGRID
                  ${URL_PROTO}github.com${URL_SEP}ORNL-Fusion/MAKEGRID.git
                  master
-                 LIBSTELL)
+                 libstell)
 
 # Register PARVMEC
 register_project(parvmec
-                 PARVMEC
                  ${URL_PROTO}github.com${URL_SEP}ORNL-Fusion/PARVMEC.git
                  master
-                 MAKEGRID
-                 LIBSTELL)
+                 makegrid
+                 libstell)
 
 # Register SIESTA
 register_project(siesta
-                 SIESTA
                  ${URL_PROTO}github.com${URL_SEP}ORNL-Fusion/SIESTA.git
                  master
-                 PARVMEC
-                 BMW)
+                 parvmec
+                 bmw)
 
 # Register V3FIT
 register_project(v3fit
-                 V3FIT
                  ${URL_PROTO}github.com${URL_SEP}cianciosa/V3FIT.git
                  master
-                 SIESTA
-                 V3RFUN
-                 LGRID)
+                 siesta
+                 v3rfun
+                 lgrid)
 
 # Register SURFACE
 register_project(surface
-                 SURFACE
                  ${URL_PROTO}github.com${URL_SEP}ORNL-Fusion/SURFACE.git
                  master
-                 BMW)
+                 bmw)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,6 @@ endif ()
 #-------------------------------------------------------------------------------
 macro (register_project name url default_tag)
     string (TOUPPER ${name} dir)
-    set (depends "${ARGN}")
 
     option (BUILD_${dir} "Build ${name} subproject." OFF)
     set (BUILD_TAG_${dir} ${default_tag} CACHE STRING "Name of the tag to checkout.")
@@ -82,7 +81,7 @@ macro (register_project name url default_tag)
             SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${dir}
         )
 
-        FetchContent_MakeAvailable(${name} ${depends})
+        FetchContent_MakeAvailable(${name})
 
         if (GIT_FOUND)
 #  By default cmake clones projects in a headless state. After the repo is
@@ -124,15 +123,32 @@ endmacro ()
 #                   SUB) #Optional Sub project directories.
 #-------------------------------------------------------------------------------
 
-# Register LIBSTELL
-register_project(libstell
-                 ${URL_PROTO}github.com${URL_SEP}ORNL-Fusion/LIBSTELL.git
-                 master)
-
+# Register BOOZ_XFORM
 register_project(booz_xform
                  ${URL_PROTO}github.com${URL_SEP}ORNL-Fusion/BOOZ_XFORM.git
                  master
                  libstell)
+
+# Register V3FIT
+register_project(v3fit
+                 ${URL_PROTO}github.com${URL_SEP}cianciosa/V3FIT.git
+                 master
+                 siesta
+                 v3rfun
+                 lgrid)
+
+# Register V3RFUN
+register_project(v3rfun
+                 ${URL_PROTO}github.com${URL_SEP}ORNL-Fusion/V3RFUN.git
+                 master
+                 libstell)
+
+# Register SIESTA
+register_project(siesta
+                 ${URL_PROTO}github.com${URL_SEP}ORNL-Fusion/SIESTA.git
+                 master
+                 parvmec
+                 bmw)
 
 # Register LGRID
 register_project(lgrid
@@ -140,11 +156,11 @@ register_project(lgrid
                  master
                  libstell)
 
-# Register V3RFUN
-register_project(v3rfun
-                 ${URL_PROTO}github.com${URL_SEP}ORNL-Fusion/V3RFUN.git
+# Register SURFACE
+register_project(surface
+                 ${URL_PROTO}github.com${URL_SEP}ORNL-Fusion/SURFACE.git
                  master
-                 libstell)
+                 bmw)
 
 # Register BMW
 register_project(bmw
@@ -158,12 +174,6 @@ register_project(descur
                  master
                  libstell)
 
-# Register MAKEGRID
-register_project(makegrid
-                 ${URL_PROTO}github.com${URL_SEP}ORNL-Fusion/MAKEGRID.git
-                 master
-                 libstell)
-
 # Register PARVMEC
 register_project(parvmec
                  ${URL_PROTO}github.com${URL_SEP}ORNL-Fusion/PARVMEC.git
@@ -171,23 +181,13 @@ register_project(parvmec
                  makegrid
                  libstell)
 
-# Register SIESTA
-register_project(siesta
-                 ${URL_PROTO}github.com${URL_SEP}ORNL-Fusion/SIESTA.git
+# Register MAKEGRID
+register_project(makegrid
+                 ${URL_PROTO}github.com${URL_SEP}ORNL-Fusion/MAKEGRID.git
                  master
-                 parvmec
-                 bmw)
+                 libstell)
 
-# Register V3FIT
-register_project(v3fit
-                 ${URL_PROTO}github.com${URL_SEP}cianciosa/V3FIT.git
-                 master
-                 siesta
-                 v3rfun
-                 lgrid)
-
-# Register SURFACE
-register_project(surface
-                 ${URL_PROTO}github.com${URL_SEP}ORNL-Fusion/SURFACE.git
-                 master
-                 bmw)
+# Register LIBSTELL
+register_project(libstell
+                 ${URL_PROTO}github.com${URL_SEP}ORNL-Fusion/LIBSTELL.git
+                 master)


### PR DESCRIPTION
The siesta mpi tests were failing because the stell target was created after the siesta target. This caused a problem with get target property needed to read the maximum number of MPI processes.